### PR TITLE
Implement lazy loading for cocktail categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ output.json
 # Other system-specific files
 .DS_Store
 Thumbs.db
+

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    namespace = "com.cocktailcraft"
+    namespace = "com.cocktailcraft.android"
     compileSdk = 34
 
     defaultConfig {

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
-        android:name=".CocktailCraftApplication"
+        android:name="com.cocktailcraft.CocktailCraftApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.CocktailBar">
         <activity
-            android:name=".MainActivity"
+            android:name="com.cocktailcraft.MainActivity"
             android:exported="true"
             android:theme="@style/Theme.CocktailBar">
             <intent-filter>

--- a/androidApp/src/main/java/com/cocktailcraft/screens/HomeScreen.kt
+++ b/androidApp/src/main/java/com/cocktailcraft/screens/HomeScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberSaveable
 import androidx.compose.runtime.setValue
 import kotlin.math.abs
 import kotlinx.coroutines.delay
@@ -101,6 +102,7 @@ import com.cocktailcraft.util.ListOptimizations.itemKey
 import com.cocktailcraft.viewmodel.CartViewModel
 import com.cocktailcraft.viewmodel.FavoritesViewModel
 import com.cocktailcraft.viewmodel.HomeViewModel
+import com.cocktailcraft.util.CocktailDebugLogger
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -126,8 +128,9 @@ fun HomeScreen(
     // State for advanced search panel
     var showAdvancedSearch by remember { mutableStateOf(false) }
 
-    // Add state for selected category
-    var selectedCategory by remember { mutableStateOf<String?>(null) }
+    // Add state for selected category - use rememberSaveable to persist across navigation
+    // Default to "Cocktail" to match lazy loading behavior
+    var selectedCategory by rememberSaveable { mutableStateOf<String?>("Cocktail") }
 
     // Function to handle category selection
     val onCategorySelected: (String?) -> Unit = { category ->
@@ -140,10 +143,34 @@ fun HomeScreen(
         onRefresh = { viewModel.retry() }
     )
 
+    // Track if this is the first composition
+    var isFirstComposition by rememberSaveable { mutableStateOf(true) }
+    
     // Effect to load cocktails by category when selected category changes
     LaunchedEffect(selectedCategory) {
+        CocktailDebugLogger.log("🏠 HomeScreen LaunchedEffect(selectedCategory): category=$selectedCategory, isSearchActive=$isSearchActive, isFirst=$isFirstComposition")
+        
+        // Skip loading on first composition if we already have data
+        if (isFirstComposition && cocktails.isNotEmpty()) {
+            CocktailDebugLogger.log("   ✅ Skipping load on first composition - already have ${cocktails.size} cocktails")
+            isFirstComposition = false
+            return@LaunchedEffect
+        }
+        
+        isFirstComposition = false
+        
+        // Only load if not in search mode and category has changed
         if (!isSearchActive) {
+            CocktailDebugLogger.log("   🏷️ Loading cocktails for category: $selectedCategory")
             viewModel.loadCocktailsByCategory(selectedCategory)
+        }
+    }
+    
+    // Effect to clear errors when screen is displayed with data
+    LaunchedEffect(cocktails) {
+        CocktailDebugLogger.log("🏠 HomeScreen LaunchedEffect(cocktails): count=${cocktails.size}, error='$legacyErrorString'")
+        if (cocktails.isNotEmpty() && legacyErrorString.isNotBlank()) {
+            viewModel.clearLegacyError()
         }
     }
 

--- a/androidApp/src/main/java/com/cocktailcraft/screens/HomeScreen.kt
+++ b/androidApp/src/main/java/com/cocktailcraft/screens/HomeScreen.kt
@@ -60,10 +60,8 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import kotlin.math.abs
-import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -75,6 +73,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import kotlin.math.abs
+import kotlinx.coroutines.delay
 import com.cocktailcraft.navigation.Screen
 import com.cocktailcraft.domain.model.Cocktail
 import com.cocktailcraft.ui.components.AdvancedSearchPanel

--- a/androidApp/src/main/java/com/cocktailcraft/ui/theme/ThemeAssets.kt
+++ b/androidApp/src/main/java/com/cocktailcraft/ui/theme/ThemeAssets.kt
@@ -3,7 +3,7 @@ package com.cocktailcraft.ui.theme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
-import com.cocktailcraft.R
+import com.cocktailcraft.android.R
 
 /**
  * Provides access to theme-specific assets throughout the app.

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -49,6 +49,10 @@ kotlin {
                 // DI
                 implementation("io.insert-koin:koin-core:3.4.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+
+                // Kache for caching
+                implementation("com.mayakapps.kache:kache:2.1.1")
+                implementation("com.mayakapps.kache:file-kache:2.1.1")
             }
         }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -50,9 +50,7 @@ kotlin {
                 implementation("io.insert-koin:koin-core:3.4.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 
-                // Kache for caching
-                implementation("com.mayakapps.kache:kache:2.1.1")
-                implementation("com.mayakapps.kache:file-kache:2.1.1")
+                // No external caching library needed - using custom implementation
             }
         }
 

--- a/shared/src/androidMain/kotlin/com/cocktailcraft/util/CocktailDebugLogger.kt
+++ b/shared/src/androidMain/kotlin/com/cocktailcraft/util/CocktailDebugLogger.kt
@@ -1,0 +1,10 @@
+package com.cocktailcraft.util
+
+import android.util.Log
+
+actual fun logInternal(message: String) {
+    // Use Log.e for now to ensure it shows up (priority 6)
+    Log.e(CocktailDebugLogger.TAG, message)
+    // Also use println as fallback
+    println("CocktailDebug: $message")
+}

--- a/shared/src/commonMain/kotlin/com/cocktailcraft/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/cocktailcraft/di/DataModule.kt
@@ -27,7 +27,11 @@ val dataModule = module {
     }
 
     // Cache
-    single { CocktailCache(get(), get(), get()) }
+    single { CocktailCache(
+        settings = get(),
+        json = get(),
+        appConfig = get()
+    ) }
 
     // Repositories
     single<CocktailRepository> {
@@ -35,8 +39,8 @@ val dataModule = module {
             api = get(),
             settings = get(),
             appConfig = get(),
-            json = get(),
-            networkMonitor = get()
+            networkMonitor = get(),
+            cocktailCache = get()
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/cocktailcraft/util/CocktailDebugLogger.kt
+++ b/shared/src/commonMain/kotlin/com/cocktailcraft/util/CocktailDebugLogger.kt
@@ -1,0 +1,16 @@
+package com.cocktailcraft.util
+
+/**
+ * Centralized debug logger for cocktail loading issues
+ */
+object CocktailDebugLogger {
+    const val TAG = "CocktailDebug"
+    
+    // Use expect/actual for platform-specific logging
+    fun log(message: String) {
+        logInternal(message)
+    }
+}
+
+// Platform-specific implementation
+expect fun logInternal(message: String)


### PR DESCRIPTION
## Summary
- Implemented lazy loading to fetch only 'Cocktail' category on initial app load
- Fixed Kotlin version compatibility issues by replacing Kache with custom LRU cache
- Fixed Android namespace conflicts and manifest configuration

## Changes
- Only fetch 'Cocktail' category on initial app load (reduces API calls from ~8 to 1)
- Implement per-category caching with 5-minute validity
- Add exponential backoff for API rate limiting (2s -> 4s -> 8s -> max 30s)
- Replace incompatible Kache library with custom SimpleLruCache implementation
- Fix Kotlin version to 1.9.22 for Compose Compiler compatibility
- Fix Android namespace and manifest package references
- Add comprehensive debug logging throughout the app

## Test plan
- [x] Build completes without errors
- [x] App launches without crashes
- [x] Cocktail categories load correctly
- [x] Lazy loading reduces initial API calls
- [x] Cache functionality works as expected
- [ ] Test offline mode with cached data
- [ ] Verify rate limiting backoff works correctly